### PR TITLE
Unintended behaviour in SerializationBinder

### DIFF
--- a/Game Engine/Bomberman/GameEngine/Renderers/GameMapRender.cs
+++ b/Game Engine/Bomberman/GameEngine/Renderers/GameMapRender.cs
@@ -28,10 +28,7 @@ namespace GameEngine.Renderers
 
         public StringBuilder RenderJsonGameState()
         {
-            return new StringBuilder(JsonConvert.SerializeObject(GameMap, minify ? Formatting.None : Formatting.Indented, new JsonSerializerSettings()
-            {
-                Binder = new EntityTypeNameHandling()
-            }));
+            return new StringBuilder(JsonConvert.SerializeObject(GameMap, minify ? Formatting.None : Formatting.Indented));
         }
 
         public virtual StringBuilder RenderTextGameState()


### PR DESCRIPTION
The SerializationBinder used for handling the types of entities has no
effect on the outcome of the state file. Is this intended to remove the
namespaces from the entity $type fields?

As a reference:

```
{
  "Entity": {
    "$type": "Domain.Entities.IndestructibleWallEntity, Domain",
    "Location": {
      "X": 2,
      "Y": 1
    }
  },
  "Bomb": null,
  "PowerUp": null,
  "Exploding": false,
  "Location": {
    "X": 2,
    "Y": 1
  }
},
```

Same outcome with or without the Binder, regardless of entity type.

Edit: As a reference, here is a cell example from last year. Each cell had a type field you could use to check what it was.

```
{
      "Id": 1,
      "Alive": true,
      "X": 0,
      "Y": 0,
      "Width": 1,
      "Height": 1,
      "Type": "Wall",
      "PlayerNumber": 0
},

```
