### PR TITLE
Fix issues on Linux (Mono)

### DIFF
--- a/Game Engine/Bomberman/TestHarness/Util/ProcessHandler.cs
+++ b/Game Engine/Bomberman/TestHarness/Util/ProcessHandler.cs
@@ -40,9 +40,8 @@ namespace TestHarness.Util
                 StartInfo =
                 {
                     WorkingDirectory = workDir,
-                    FileName = Environment.OSVersion.Platform == PlatformID.Unix && !isMono ? "/bin/bash " : processName,
-                    Arguments =
-						Environment.OSVersion.Platform == PlatformID.Unix && !isMono ? processName + " " + processArgs : processArgs,
+                    FileName = processName,
+                    Arguments = processArgs,
                     CreateNoWindow = true,
                     WindowStyle = ProcessWindowStyle.Hidden,
                     UseShellExecute = false,
@@ -80,7 +79,10 @@ namespace TestHarness.Util
             _processToRun.Start();
             _processToRun.BeginOutputReadLine();
             _processToRun.BeginErrorReadLine();
-            _processToRun.PriorityClass = ProcessPriorityClass.AboveNormal;
+            if (Environment.OSVersion.Platform != PlatformID.Unix) {
+                // On Linux root permissions are required to change the PriorityClass
+                _processToRun.PriorityClass = ProcessPriorityClass.AboveNormal;
+            }
 
             _logger.LogInfo("Bot has " + (TimeSpan.FromSeconds(Settings.Default.MaxBotRuntimeSeconds * 2).TotalMilliseconds) + "ms to run");
             var cleanExit = true;


### PR DESCRIPTION
This makes allows the bot processes to run on Linux using Mono, and most likely on OS X as well.

There was an existing `!isMono` check, but `isMono` is always false.

I'm not sure if there is any scenario in which the `/bin/bash` mode is required, but it failed on my machine.

I also had to disable the `PriorityClass` setting to enable me to run the bot without sudo. I'm assuming the process priority will not be significant except for the actual tournaments.

I got this working with a Python bot. The main other thing I had to change was `PathToPython2/3` in the config file (not sure which one - I changed it in all of them).
