### PR TITLE
Display seed-seed on console, not seed.

### DIFF
--- a/Game Engine/BomberManUnity/Engine/UnityEngine.cs
+++ b/Game Engine/BomberManUnity/Engine/UnityEngine.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 using BomberManUnity.Loggers;
 using BomberManUnity.Players;
 using Domain.Common;
 using GameEngine.Commands.PlayerCommands;
-using GameEngine.Engine;
+using GameEngine.Common;
 using GameEngine.MapGenerator;
 
 namespace BomberManUnity.Engine
@@ -14,13 +14,13 @@ namespace BomberManUnity.Engine
     {
         private GameMap _gameMap;
         private UnityRoundProcessor _roundProcessor;
-        private List<UnityPlayer> _players;
+        private List<Player> _players;
 
         public void PrepareNewGame(List<UnityPlayer> players, int seed)
         {
-            var mapGenerator = new GameMapGenerator<UnityPlayer>(players);
+            _players = players.Cast<Player>().ToList();
+            var mapGenerator = new GameMapGenerator(_players);
             _gameMap = mapGenerator.GenerateGameMap(seed);
-            _players = players;
         }
 
         public void StartNewGame()

--- a/Game Engine/Bomberman/GameEngine/Engine/BombermanEngine.cs
+++ b/Game Engine/Bomberman/GameEngine/Engine/BombermanEngine.cs
@@ -41,25 +41,7 @@ namespace GameEngine.Engine
         /// <exception cref="MapUnsuitableException">Will throw an exception if the seed produces an unsuitable map</exception>
         public void PrepareGame(List<Player> players, int seed)
         {
-            var seedGenerator = new Random(seed);
-            var randomSeed = seedGenerator.Next();
-            var generationOk = false;
-            while (!generationOk)
-            {
-                Logger.LogInfo("Trying seed " + randomSeed + "...");
-
-                try
-                {
-                    var mapGenerator = new GameMapGenerator<Player>(players);
-                    _gameMap = mapGenerator.GenerateGameMap(randomSeed);
-                    generationOk = true;
-                }
-                catch (MapUnsuitableException ex)
-                {
-                    Logger.LogException("Map not suitable with seed, trying a new one.", ex);
-                    randomSeed = seedGenerator.Next();
-                }
-            }
+            _gameMap = (new GameMapGenerator(players)).GenerateGameMap(seed);
 
             _players = players;
             _currentRound = 0;


### PR DESCRIPTION
`GameMapGenerator` creates a seed from the seed to generate the map.  
"Seed-seed" is the number that is passed in via command line and which is used for the Replays folder path. This is the number that must be displayed on the console so that users can use this number to easily reproduce the same map.
