### PR TITLE
DotNetRunner: Fix bot file path for Unix systems.

### DIFF
--- a/Game Engine/Bomberman/TestHarness/TestHarnesses/Bot/Runners/DotNetRunner.cs
+++ b/Game Engine/Bomberman/TestHarness/TestHarnesses/Bot/Runners/DotNetRunner.cs
@@ -23,7 +23,7 @@ namespace TestHarness.TestHarnesses.Bot.Runners
             
             processArgs = AddAdditionalRunArgs(processArgs);
 
-            return new ProcessHandler(botDir, ConvertProcessName(processName), ConvertProcessArgs(processName, processArgs), ParentHarness.Logger, true);
+            return new ProcessHandler(botDir, ConvertProcessName(processName), ConvertProcessArgs(botFile, processArgs), ParentHarness.Logger, true);
         }
 
         protected override void RunCalibrationTest()


### PR DESCRIPTION
When running Bomberman.exe on Mac OS X using mono, the command for invoking the C# sample bot failed.  
The command was:

```
mono "../../../../Sample Bots/C#/bin/Debug/SampleBot.exe" ...
```

which failed with `Cannot open assembly '../../../../Sample Bots/C#/bin/Debug/SampleBot.exe': No such file or directory.`

This happens because `DotNetRunner` sets the process' working directory to the directory of the bot, so mono searches relative to this directory. Therefore the bot directory must not be included in the command.

The correct command is:

```
mono "bin/Debug/SampleBot.exe" ...
```
